### PR TITLE
Switch Python client to setuptools

### DIFF
--- a/session_py_client/pyproject.toml
+++ b/session_py_client/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "session_py_client"
+version = "0.1.0"
+description = "Python client for Session"
+license = {text = "MIT"}
+authors = [
+    {name = "Example", email = "example@example.com"}
+]
+dependencies = [
+    "pynacl",
+    "protobuf",
+    "aiohttp",
+    "typing",
+    "dataclasses"
+]
+


### PR DESCRIPTION
## Summary
- rework `pyproject.toml` to use setuptools for `session_py_client`

## Testing
- `bun test` *(fails: fetch_failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c41e197c8832ea61a28b2b5bdeb99