### PR TITLE
Add Python utils with validation

### DIFF
--- a/session_py_client/__init__.py
+++ b/session_py_client/__init__.py
@@ -1,0 +1,30 @@
+from .utils import (
+    Uint8ArrayToHex,
+    hexToUint8Array,
+    concatUInt8Array,
+    removePrefixIfNeeded,
+    isHex,
+    Uint8ArrayToBase64,
+    base64ToUint8Array,
+    Deferred,
+    checkStorage,
+    checkNetwork,
+    SessionValidationError,
+    SessionValidationErrorCode,
+)
+
+__all__ = [
+    "Uint8ArrayToHex",
+    "hexToUint8Array",
+    "concatUInt8Array",
+    "removePrefixIfNeeded",
+    "isHex",
+    "Uint8ArrayToBase64",
+    "base64ToUint8Array",
+    "Deferred",
+    "checkStorage",
+    "checkNetwork",
+    "SessionValidationError",
+    "SessionValidationErrorCode",
+]
+

--- a/session_py_client/tests/test_utils.py
+++ b/session_py_client/tests/test_utils.py
@@ -1,0 +1,89 @@
+import asyncio
+import pytest
+
+from session_py_client.utils import (
+    Uint8ArrayToHex,
+    hexToUint8Array,
+    concatUInt8Array,
+    removePrefixIfNeeded,
+    isHex,
+    Uint8ArrayToBase64,
+    base64ToUint8Array,
+    Deferred,
+    checkStorage,
+    checkNetwork,
+    SessionValidationError,
+    SessionValidationErrorCode,
+)
+
+
+def test_hex_conversions():
+    data = b"\x01\x02\xab"
+    hex_str = Uint8ArrayToHex(data)
+    assert hex_str == "0102ab"
+    assert hexToUint8Array(hex_str) == data
+
+
+def test_concat_and_prefix():
+    res = concatUInt8Array(b"ab", b"cd")
+    assert res == b"abcd"
+    assert removePrefixIfNeeded(b"\x05\xff") == b"\xff"
+    assert removePrefixIfNeeded("05ff") == "ff"
+    assert removePrefixIfNeeded(b"ab") == b"ab"
+    assert removePrefixIfNeeded("ab") == "ab"
+
+
+def test_is_hex():
+    assert isHex("deadbeef")
+    assert not isHex("xyz")
+
+
+def test_base64_conversions():
+    data = b"hello"
+    encoded = Uint8ArrayToBase64(data)
+    assert base64ToUint8Array(encoded) == data
+
+
+def test_deferred():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    d = Deferred[int]()
+
+    loop.call_soon(d.resolve, 5)
+    result = loop.run_until_complete(d.promise)
+    loop.close()
+    asyncio.set_event_loop(None)
+    assert result == 5
+
+
+def test_check_storage_network():
+    class Storage:
+        def get(self, key):
+            return None
+
+        def set(self, key, value):
+            pass
+
+        def delete(self, key):
+            pass
+
+        def has(self, key):
+            return False
+
+    class Network:
+        async def on_request(self, type_, body):
+            return None
+
+    checkStorage(Storage())
+    checkNetwork(Network())
+
+    with pytest.raises(SessionValidationError) as exc:
+        checkStorage(object())
+    assert exc.value.code == SessionValidationErrorCode.INVALID_OPTIONS
+
+    class BadNetwork:
+        pass
+
+    with pytest.raises(SessionValidationError):
+        checkNetwork(BadNetwork())
+

--- a/session_py_client/utils.py
+++ b/session_py_client/utils.py
@@ -1,0 +1,148 @@
+"""
+Utility helpers for Session Python client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from enum import Enum
+from typing import Any, Iterable, Generic, TypeVar, Union
+
+
+class SessionValidationErrorCode(str, Enum):
+    """Error codes used for validation errors."""
+
+    INVALID_OPTIONS = "invalid_options"
+
+
+class SessionValidationError(Exception):
+    """Validation error, indicates developer provided invalid input."""
+
+    def __init__(self, code: SessionValidationErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+T = TypeVar("T")
+
+
+class Deferred(Generic[T]):
+    """A simple deferred future implementation."""
+
+    def __init__(self) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.get_event_loop()
+        self.future: asyncio.Future[T] = loop.create_future()
+
+    @property
+    def promise(self) -> asyncio.Future[T]:
+        """Return the underlying future."""
+
+        return self.future
+
+    def resolve(self, value: T) -> None:
+        """Resolve the future with a value."""
+
+        if not self.future.done():
+            self.future.set_result(value)
+
+    def reject(self, reason: Exception) -> None:
+        """Reject the future with an exception."""
+
+        if not self.future.done():
+            self.future.set_exception(reason)
+
+
+def Uint8ArrayToHex(data: bytes | bytearray) -> str:
+    """Convert bytes-like object to hex string."""
+
+    return bytes(data).hex()
+
+
+def hexToUint8Array(hex_string: str) -> bytes:
+    """Convert hex string to bytes, ignoring invalid trailing characters."""
+
+    if not hex_string:
+        return b""
+    output = bytearray()
+    length = len(hex_string) // 2
+    for i in range(length):
+        pair = hex_string[2 * i : 2 * i + 2]
+        try:
+            output.append(int(pair, 16))
+        except ValueError:
+            break
+    return bytes(output)
+
+
+def concatUInt8Array(*arrays: Iterable[bytes]) -> bytes:
+    """Concatenate multiple byte sequences."""
+
+    return b"".join(bytes(a) for a in arrays)
+
+
+def removePrefixIfNeeded(value: Union[str, bytes, bytearray]) -> Union[str, bytes]:
+    """Remove 0x05 prefix from string or bytes if present."""
+
+    if isinstance(value, (bytes, bytearray)):
+        data = bytes(value)
+        if data[:1] == b"\x05":
+            return data[1:]
+        return data
+    if isinstance(value, str) and value.startswith("05"):
+        return value[2:]
+    return value
+
+
+def isHex(value: str) -> bool:
+    """Check if a string consists only of hex pairs."""
+
+    return bool(value) and bool(__import__("re").fullmatch(r"([0-9a-fA-F]{2})+", value))
+
+
+def Uint8ArrayToBase64(data: bytes | bytearray) -> str:
+    """Encode bytes-like object to base64 string."""
+
+    return base64.b64encode(bytes(data)).decode("ascii")
+
+
+def base64ToUint8Array(data: str) -> bytes:
+    """Decode base64 string to bytes."""
+
+    return base64.b64decode(data)
+
+
+def checkStorage(storage: Any) -> None:
+    """Validate that a storage object implements required methods."""
+
+    if not isinstance(storage, object):
+        raise SessionValidationError(
+            SessionValidationErrorCode.INVALID_OPTIONS, "Provided storage is invalid"
+        )
+    for method in ("get", "set", "delete", "has"):
+        attr = getattr(storage, method, None)
+        if not callable(attr):
+            raise SessionValidationError(
+                SessionValidationErrorCode.INVALID_OPTIONS,
+                f"Provided storage does not have method {method}",
+            )
+
+
+def checkNetwork(network: Any) -> None:
+    """Validate that a network object implements required methods."""
+
+    if not isinstance(network, object):
+        raise SessionValidationError(
+            SessionValidationErrorCode.INVALID_OPTIONS, "Provided network is invalid"
+        )
+    attr = getattr(network, "on_request", None)
+    if not callable(attr):
+        raise SessionValidationError(
+            SessionValidationErrorCode.INVALID_OPTIONS,
+            "Provided network does not have method on_request",
+        )
+


### PR DESCRIPTION
## Summary
- add Python utilities for data conversions in `session_py_client`
- implement Deferred helper and validation checks for storage and network
- expose utilities via package `__init__`
- test conversion helpers and validation logic

## Testing
- `pytest session_py_client -q`

------
https://chatgpt.com/codex/tasks/task_e_686c43d5036c832ebbf229c4b19f410d