### PR TITLE
feat(attachments): add encryption and decryption utilities

### DIFF
--- a/session_py_client/__init__.py
+++ b/session_py_client/__init__.py
@@ -12,6 +12,12 @@ from .utils import (
     SessionValidationError,
     SessionValidationErrorCode,
 )
+from .attachments.encrypt import (
+    encryptFileAttachment,
+    encryptAttachmentData,
+    addAttachmentPadding,
+)
+from .attachments.decrypt import decryptAttachment
 
 __all__ = [
     "Uint8ArrayToHex",
@@ -26,5 +32,9 @@ __all__ = [
     "checkNetwork",
     "SessionValidationError",
     "SessionValidationErrorCode",
+    "encryptFileAttachment",
+    "encryptAttachmentData",
+    "decryptAttachment",
+    "addAttachmentPadding",
 ]
 

--- a/session_py_client/attachments/decrypt.py
+++ b/session_py_client/attachments/decrypt.py
@@ -1,0 +1,69 @@
+"""Attachment decryption utilities."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import hashes, hmac, padding
+import hmac as py_hmac
+
+
+def decryptAttachment(
+    data: bytes,
+    *,
+    size: Optional[int] = None,
+    keyBuffer: bytes,
+    digestBuffer: bytes,
+) -> bytes:
+    """Decrypt attachment data verifying MAC and digest."""
+
+    if len(keyBuffer) != 64:
+        raise ValueError("Got invalid length attachment keys")
+    if len(data) < 16 + 32:
+        raise ValueError("Got invalid length attachment")
+
+    aes_key = keyBuffer[:32]
+    mac_key = keyBuffer[32:]
+    iv = data[:16]
+    ciphertext = data[16:-32]
+    iv_and_ciphertext = data[:-32]
+    mac = data[-32:]
+
+    _verify_mac(iv_and_ciphertext, mac_key, mac)
+    _verify_digest(data, digestBuffer)
+
+    cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv))
+    decryptor = cipher.decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+
+    unpadder = padding.PKCS7(128).unpadder()
+    decrypted_data = unpadder.update(padded) + unpadder.finalize()
+
+    if size is not None and size != len(data):
+        if size < len(data):
+            decrypted_data = decrypted_data[:size]
+        else:
+            raise ValueError("Decrypted attachment size does not match expected size")
+
+    return decrypted_data
+
+
+def _verify_mac(data: bytes, key: bytes, mac: bytes) -> None:
+    """Validate HMAC of attachment data."""
+
+    h = hmac.HMAC(key, hashes.SHA256())
+    h.update(data)
+    calculated = h.finalize()
+    if not py_hmac.compare_digest(calculated[: len(mac)], mac):
+        raise ValueError("Bad attachment MAC")
+
+
+def _verify_digest(data: bytes, digest_value: bytes) -> None:
+    """Validate SHA-256 digest of encrypted attachment."""
+
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(data)
+    calculated = digest.finalize()
+    if not py_hmac.compare_digest(calculated[: len(digest_value)], digest_value):
+        raise ValueError("Bad attachment digest")

--- a/session_py_client/attachments/encrypt.py
+++ b/session_py_client/attachments/encrypt.py
@@ -1,0 +1,76 @@
+"""Attachment encryption utilities."""
+
+from __future__ import annotations
+
+from typing import BinaryIO, Dict
+from math import ceil, log, pow
+
+from nacl.utils import random as nacl_random
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import hashes, hmac, padding
+
+PADDING_BYTE = 0x00
+MAX_ATTACHMENT_FILESIZE_BYTES = 10 * 1000 * 1000
+
+
+def addAttachmentPadding(data: bytes) -> bytes:
+    """Add padding to attachment data to obscure its real size."""
+
+    original_len = len(data)
+    padded_size = max(
+        541,
+        int(pow(1.05, ceil(log(max(original_len, 1), 1.05)))),
+    )
+    if padded_size > MAX_ATTACHMENT_FILESIZE_BYTES and original_len <= MAX_ATTACHMENT_FILESIZE_BYTES:
+        padded_size = MAX_ATTACHMENT_FILESIZE_BYTES
+    padding_len = padded_size - original_len
+    return data + bytes([PADDING_BYTE]) * padding_len
+
+
+def encryptFileAttachment(file_obj: BinaryIO) -> Dict[str, bytes]:
+    """Encrypt a file attachment using random keys."""
+
+    data = file_obj.read()
+    return encryptAttachment(data, add_padding=True)
+
+
+def encryptAttachment(data: bytes, add_padding: bool = False) -> Dict[str, bytes]:
+    """Encrypt attachment bytes and return ciphertext, digest and key."""
+
+    pointer_key = nacl_random(64)
+    iv = nacl_random(16)
+    padded = addAttachmentPadding(data) if add_padding else data
+    encrypted = encryptAttachmentData(padded, pointer_key, iv)
+    encrypted["key"] = pointer_key
+    return encrypted
+
+
+def encryptAttachmentData(plaintext: bytes, keys: bytes, iv: bytes) -> Dict[str, bytes]:
+    """Encrypt attachment data using AES-CBC and HMAC-SHA256."""
+
+    if len(keys) != 64:
+        raise ValueError("Got invalid length attachment keys")
+    if len(iv) != 16:
+        raise ValueError("Got invalid length attachment iv")
+
+    aes_key = keys[:32]
+    mac_key = keys[32:]
+
+    padder = padding.PKCS7(128).padder()
+    padded_data = padder.update(plaintext) + padder.finalize()
+    cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv))
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded_data) + encryptor.finalize()
+
+    iv_and_ciphertext = iv + ciphertext
+    h = hmac.HMAC(mac_key, hashes.SHA256())
+    h.update(iv_and_ciphertext)
+    mac = h.finalize()
+
+    encrypted_bin = iv_and_ciphertext + mac
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(encrypted_bin)
+    return {
+        "ciphertext": encrypted_bin,
+        "digest": digest.finalize(),
+    }

--- a/session_py_client/pyproject.toml
+++ b/session_py_client/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "protobuf",
     "aiohttp",
     "typing",
-    "dataclasses"
+    "dataclasses",
+    "cryptography"
 ]
 

--- a/session_py_client/tests/test_attachments.py
+++ b/session_py_client/tests/test_attachments.py
@@ -1,0 +1,54 @@
+import pytest
+
+from session_py_client.attachments.encrypt import (
+    encryptFileAttachment,
+    encryptAttachmentData,
+    addAttachmentPadding,
+)
+from session_py_client.attachments.decrypt import decryptAttachment
+
+
+def test_padding_increases_size():
+    data = b"abc"
+    padded = addAttachmentPadding(data)
+    assert len(padded) >= len(data)
+    assert padded.startswith(data)
+
+
+def test_encrypt_decrypt_roundtrip(tmp_path):
+    original = b"hello world"
+    file_path = tmp_path / "f.txt"
+    file_path.write_bytes(original)
+
+    with open(file_path, "rb") as f:
+        enc = encryptFileAttachment(f)
+
+    assert set(enc.keys()) == {"ciphertext", "digest", "key"}
+
+    dec = decryptAttachment(
+        enc["ciphertext"],
+        size=len(original),
+        keyBuffer=enc["key"],
+        digestBuffer=enc["digest"],
+    )
+    assert dec == original
+
+
+def test_bad_digest_raises(tmp_path):
+    original = b"data"
+    file_path = tmp_path / "f.bin"
+    file_path.write_bytes(original)
+
+    with open(file_path, "rb") as f:
+        enc = encryptFileAttachment(f)
+
+    bad_digest = bytearray(enc["digest"])
+    bad_digest[0] ^= 0xFF
+
+    with pytest.raises(ValueError):
+        decryptAttachment(
+            enc["ciphertext"],
+            size=len(original),
+            keyBuffer=enc["key"],
+            digestBuffer=bytes(bad_digest),
+        )


### PR DESCRIPTION
## Summary
- add new attachment encryption/decryption modules for Python
- expose new helpers in package init
- test encryption and decryption routines
- include cryptography as a dependency

## Testing
- `python -m pip install -e session_py_client`
- `pytest -q session_py_client/tests`

------
https://chatgpt.com/codex/tasks/task_e_686c44f60c0c832eadd6bf9193e22863