### PR TITLE
feat(profile): add AES-GCM utils and serialization

### DIFF
--- a/session_py_client/__init__.py
+++ b/session_py_client/__init__.py
@@ -12,6 +12,19 @@ from .utils import (
     SessionValidationError,
     SessionValidationErrorCode,
 )
+from .profile import (
+    PROFILE_IV_LENGTH,
+    PROFILE_KEY_LENGTH,
+    PROFILE_TAG_LENGTH,
+    Avatar,
+    Profile,
+    serialize_profile,
+    deserialize_profile,
+    encrypt_profile,
+    decrypt_profile,
+    download_avatar,
+    upload_avatar,
+)
 
 __all__ = [
     "Uint8ArrayToHex",
@@ -26,5 +39,16 @@ __all__ = [
     "checkNetwork",
     "SessionValidationError",
     "SessionValidationErrorCode",
+    "PROFILE_IV_LENGTH",
+    "PROFILE_KEY_LENGTH",
+    "PROFILE_TAG_LENGTH",
+    "Avatar",
+    "Profile",
+    "serialize_profile",
+    "deserialize_profile",
+    "encrypt_profile",
+    "decrypt_profile",
+    "download_avatar",
+    "upload_avatar",
 ]
 

--- a/session_py_client/profile/__init__.py
+++ b/session_py_client/profile/__init__.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+import os
+
+PROFILE_IV_LENGTH = 12  # bytes
+PROFILE_KEY_LENGTH = 32  # bytes
+PROFILE_TAG_LENGTH = 128  # bits
+
+from .encrypt import encrypt_profile
+from .decrypt import decrypt_profile
+
+
+@dataclass
+class Avatar:
+    url: str
+    key: bytes
+
+
+@dataclass
+class Profile:
+    display_name: str
+    avatar: Optional[Avatar] = None
+
+
+def serialize_profile(profile: Profile) -> Dict[str, Any]:
+    '''
+    Serialize a Profile instance into a dictionary.
+
+    Args:
+        profile (Profile): Profile instance to serialize.
+
+    Returns:
+        Dict[str, Any]: Dictionary with ``lokiProfile`` and ``profileKey`` fields.
+    '''
+    signal_profile = None
+    if profile.avatar or profile.display_name:
+        signal_profile = {}
+        if profile.avatar and profile.avatar.url and len(profile.avatar.key):
+            signal_profile["profilePicture"] = profile.avatar.url
+        if profile.display_name:
+            signal_profile["displayName"] = profile.display_name
+
+    return {
+        "lokiProfile": signal_profile,
+        "profileKey": profile.avatar.key if profile.avatar else None,
+    }
+
+
+def deserialize_profile(data: Dict[str, Any]) -> Profile:
+    '''
+    Create a Profile instance from serialized data.
+
+    Args:
+        data (Dict[str, Any]): Serialized profile dictionary.
+
+    Returns:
+        Profile: Restored profile object.
+    '''
+    loki_profile = data.get("lokiProfile") or {}
+    display_name = loki_profile.get("displayName", "")
+    avatar = None
+    avatar_url = loki_profile.get("profilePicture")
+    profile_key = data.get("profileKey")
+    if avatar_url and profile_key:
+        avatar = Avatar(url=avatar_url, key=profile_key)
+    return Profile(display_name=display_name, avatar=avatar)
+
+
+async def download_avatar(self, avatar: Avatar) -> bytes:
+    '''
+    Download and decrypt avatar image using Session network.
+
+    Args:
+        self: Session-like object with ``_request`` coroutine.
+        avatar (Avatar): Avatar descriptor with ``url`` and ``key``.
+
+    Returns:
+        bytes: Decrypted avatar image.
+    '''
+    file_server_url = "http://filev2.getsession.org/file/"
+    if not avatar.url.startswith(file_server_url):
+        raise ValueError("Avatar must be hosted on Session file server")
+
+    file_id = avatar.url[len(file_server_url) :]
+    if not file_id.isdigit():
+        raise ValueError("Invalid avatar file ID")
+
+    avatar_file = await self._request(
+        {
+            "type": "DownloadAttachment",
+            "body": {"id": file_id},
+        }
+    )
+    return decrypt_profile(avatar_file, avatar.key)
+
+
+async def upload_avatar(self, avatar: bytes) -> Dict[str, Any]:
+    '''
+    Encrypt and upload avatar to the file server.
+
+    Args:
+        self: Session-like object with ``_request`` coroutine.
+        avatar (bytes): Raw avatar image.
+
+    Returns:
+        Dict[str, Any]: Dictionary with ``profileKey`` and ``avatarPointer``.
+    '''
+    profile_key = os.urandom(PROFILE_KEY_LENGTH)
+    encrypted_avatar = encrypt_profile(avatar, profile_key)
+    upload_request = await self._request(
+        {
+            "type": "UploadAttachment",
+            "body": {"data": encrypted_avatar},
+        }
+    )
+    return {"profileKey": profile_key, "avatarPointer": upload_request["url"]}
+
+__all__ = [
+    "PROFILE_IV_LENGTH",
+    "PROFILE_KEY_LENGTH",
+    "PROFILE_TAG_LENGTH",
+    "Avatar",
+    "Profile",
+    "serialize_profile",
+    "deserialize_profile",
+    "encrypt_profile",
+    "decrypt_profile",
+    "download_avatar",
+    "upload_avatar",
+]

--- a/session_py_client/profile/decrypt.py
+++ b/session_py_client/profile/decrypt.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from . import PROFILE_IV_LENGTH, PROFILE_KEY_LENGTH, PROFILE_TAG_LENGTH
+
+
+def decrypt_profile(data: bytes, key: bytes) -> bytes:
+    '''
+    Decrypt profile data previously encrypted with `encrypt_profile`.
+
+    Args:
+        data (bytes): Concatenation of IV and ciphertext with tag.
+        key (bytes): Encryption key of length PROFILE_KEY_LENGTH.
+
+    Returns:
+        bytes: Decrypted plaintext.
+    '''
+    min_length = PROFILE_IV_LENGTH + PROFILE_TAG_LENGTH // 8 + 1
+    if len(data) < min_length:
+        raise ValueError(f"Got too short input: {len(data)}")
+
+    iv = data[:PROFILE_IV_LENGTH]
+    ciphertext = data[PROFILE_IV_LENGTH:]
+    if len(key) != PROFILE_KEY_LENGTH:
+        raise ValueError("Invalid profile key length")
+    if len(iv) != PROFILE_IV_LENGTH:
+        raise ValueError("Invalid profile iv length")
+
+    aesgcm = AESGCM(key)
+    try:
+        return aesgcm.decrypt(iv, ciphertext, None)
+    except Exception as exc:
+        raise ValueError("Failed to decrypt profile data") from exc

--- a/session_py_client/profile/encrypt.py
+++ b/session_py_client/profile/encrypt.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from . import PROFILE_IV_LENGTH, PROFILE_KEY_LENGTH
+
+
+def encrypt_profile(data: bytes, key: bytes) -> bytes:
+    '''
+    Encrypt profile data using AES-GCM.
+
+    Args:
+        data (bytes): Plain profile data to encrypt.
+        key (bytes): Encryption key of length PROFILE_KEY_LENGTH.
+
+    Returns:
+        bytes: IV prepended to the encrypted data and tag.
+    '''
+    if len(key) != PROFILE_KEY_LENGTH:
+        raise ValueError("Invalid profile key length")
+
+    iv = os.urandom(PROFILE_IV_LENGTH)
+    if len(iv) != PROFILE_IV_LENGTH:
+        raise ValueError("Invalid IV length generated")
+
+    aesgcm = AESGCM(key)
+    ciphertext = aesgcm.encrypt(iv, data, None)
+    return iv + ciphertext

--- a/session_py_client/tests/test_profile.py
+++ b/session_py_client/tests/test_profile.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+
+from session_py_client.profile import (
+    PROFILE_IV_LENGTH,
+    PROFILE_KEY_LENGTH,
+    PROFILE_TAG_LENGTH,
+    encrypt_profile,
+    decrypt_profile,
+)
+
+
+def test_encrypt_decrypt_roundtrip():
+    data = b"test data"
+    key = os.urandom(PROFILE_KEY_LENGTH)
+    encrypted = encrypt_profile(data, key)
+    assert len(encrypted) >= PROFILE_IV_LENGTH + len(data) + PROFILE_TAG_LENGTH // 8
+    decrypted = decrypt_profile(encrypted, key)
+    assert decrypted == data
+
+
+def test_invalid_key_length():
+    with pytest.raises(ValueError):
+        encrypt_profile(b"data", b"short")
+    with pytest.raises(ValueError):
+        decrypt_profile(b"\x00" * (PROFILE_IV_LENGTH + PROFILE_TAG_LENGTH // 8 + 1), b"short")
+
+
+def test_too_short_input():
+    key = os.urandom(PROFILE_KEY_LENGTH)
+    with pytest.raises(ValueError):
+        decrypt_profile(b"\x00" * (PROFILE_IV_LENGTH + PROFILE_TAG_LENGTH // 8), key)


### PR DESCRIPTION
## Summary
- implement AES-GCM encrypt/decrypt helpers
- provide profile helpers and constants
- export profile helpers from package
- test profile encryption functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c44f4c290832e82214cbd5544e98a