### PR TITLE
Add in-memory storage for python client

### DIFF
--- a/session_py_client/__init__.py
+++ b/session_py_client/__init__.py
@@ -12,6 +12,7 @@ from .utils import (
     SessionValidationError,
     SessionValidationErrorCode,
 )
+from .storage import InMemoryStorage, Storage
 
 __all__ = [
     "Uint8ArrayToHex",
@@ -26,5 +27,7 @@ __all__ = [
     "checkNetwork",
     "SessionValidationError",
     "SessionValidationErrorCode",
+    "InMemoryStorage",
+    "Storage",
 ]
 

--- a/session_py_client/storage/__init__.py
+++ b/session_py_client/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage implementations for Session Python client."""
+
+from .in_memory import InMemoryStorage, Storage
+
+__all__ = ["InMemoryStorage", "Storage"]

--- a/session_py_client/storage/in_memory.py
+++ b/session_py_client/storage/in_memory.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Storage(Protocol):
+    """Interface for storage implementations."""
+
+    def get(self, key: str) -> Optional[str]:
+        """Retrieve a value by key."""
+
+    def set(self, key: str, value: str) -> None:
+        """Store a value by key."""
+
+    def delete(self, key: str) -> None:
+        """Remove a value by key."""
+
+    def has(self, key: str) -> bool:
+        """Check if a key exists."""
+
+
+class InMemoryStorage:
+    """Simple in-memory storage using a dictionary."""
+
+    def __init__(self) -> None:
+        self._storage: dict[str, str] = {}
+
+    def get(self, key: str) -> Optional[str]:
+        """Return the stored value for key if present."""
+
+        return self._storage.get(key)
+
+    def set(self, key: str, value: str) -> None:
+        """Set key to given value."""
+
+        self._storage[key] = value
+
+    def delete(self, key: str) -> None:
+        """Delete key from storage if it exists."""
+
+        self._storage.pop(key, None)
+
+    def has(self, key: str) -> bool:
+        """Return ``True`` if key exists in storage."""
+
+        return key in self._storage
+

--- a/session_py_client/tests/test_storage.py
+++ b/session_py_client/tests/test_storage.py
@@ -1,0 +1,19 @@
+
+from session_py_client.storage import InMemoryStorage, Storage
+
+
+def test_in_memory_storage_basic():
+    storage = InMemoryStorage()
+
+    assert isinstance(storage, Storage)
+    assert storage.get("a") is None
+    assert not storage.has("a")
+
+    storage.set("a", "1")
+    assert storage.get("a") == "1"
+    assert storage.has("a")
+
+    storage.delete("a")
+    assert storage.get("a") is None
+    assert not storage.has("a")
+


### PR DESCRIPTION
## Summary
- expose Storage interface and new InMemoryStorage
- test that InMemoryStorage operates with a dictionary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c44e6c0c4832e8277b9f22e9a84c4