### PR TITLE
feat: add crypto message encryption/decryption

### DIFF
--- a/session_py_client/__init__.py
+++ b/session_py_client/__init__.py
@@ -34,6 +34,26 @@ from .attachments.encrypt import (
     addAttachmentPadding,
 )
 from .attachments.decrypt import decryptAttachment
+from .crypto import (
+    add_message_padding,
+    remove_message_padding,
+    Keypair,
+    SodiumKeyPair,
+    Envelope,
+    EnvelopeType,
+    EncryptResult,
+    generate_keypair,
+    encrypt,
+    wrap_envelope,
+    build_envelope,
+    wrap,
+    EnvelopePlus,
+    extract_content,
+    decode_message,
+    decrypt_message,
+    decrypt_envelope_with_our_key,
+    decrypt_with_session_protocol,
+)
 
 __all__ = [
     "Uint8ArrayToHex",
@@ -65,5 +85,23 @@ __all__ = [
     "encryptAttachmentData",
     "decryptAttachment",
     "addAttachmentPadding",
+    "add_message_padding",
+    "remove_message_padding",
+    "Keypair",
+    "SodiumKeyPair",
+    "Envelope",
+    "EnvelopeType",
+    "EncryptResult",
+    "generate_keypair",
+    "encrypt",
+    "wrap_envelope",
+    "build_envelope",
+    "wrap",
+    "EnvelopePlus",
+    "extract_content",
+    "decode_message",
+    "decrypt_message",
+    "decrypt_envelope_with_our_key",
+    "decrypt_with_session_protocol",
 ]
 

--- a/session_py_client/crypto/__init__.py
+++ b/session_py_client/crypto/__init__.py
@@ -1,0 +1,44 @@
+"""Crypto helpers for Session Python client."""
+
+from .message_padding import add_message_padding, remove_message_padding
+from .message_encrypt import (
+    Keypair,
+    SodiumKeyPair,
+    Envelope,
+    EnvelopeType,
+    EncryptResult,
+    generate_keypair,
+    encrypt,
+    wrap_envelope,
+    build_envelope,
+    wrap,
+)
+from .message_decrypt import (
+    EnvelopePlus,
+    extract_content,
+    decode_message,
+    decrypt_message,
+    decrypt_envelope_with_our_key,
+    decrypt_with_session_protocol,
+)
+
+__all__ = [
+    "add_message_padding",
+    "remove_message_padding",
+    "Keypair",
+    "SodiumKeyPair",
+    "Envelope",
+    "EnvelopeType",
+    "EncryptResult",
+    "generate_keypair",
+    "encrypt",
+    "wrap_envelope",
+    "build_envelope",
+    "wrap",
+    "EnvelopePlus",
+    "extract_content",
+    "decode_message",
+    "decrypt_message",
+    "decrypt_envelope_with_our_key",
+    "decrypt_with_session_protocol",
+]

--- a/session_py_client/crypto/message_decrypt.py
+++ b/session_py_client/crypto/message_decrypt.py
@@ -1,0 +1,214 @@
+"""Message decryption helpers using PyNaCl."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from nacl import bindings, signing
+
+from ..utils import (
+    Uint8ArrayToHex,
+    base64ToUint8Array,
+    concatUInt8Array,
+    removePrefixIfNeeded,
+)
+from .message_padding import remove_message_padding
+from .message_encrypt import (
+    Envelope,
+    EnvelopeType,
+    Keypair,
+)
+
+
+@dataclass
+class EnvelopePlus:
+    """Envelope with some additional metadata."""
+
+    id: str
+    source: Optional[str]
+    content: bytes
+    receivedAt: int
+    senderIdentity: Optional[str]
+    timestamp: int
+    type: EnvelopeType
+
+
+def extract_content(message: str) -> Optional[bytes]:
+    """
+    Extract envelope bytes from a wrapped websocket message.
+
+    Args:
+        message (str): Base64 encoded websocket message.
+
+    Returns:
+        Optional[bytes]: Envelope bytes if present.
+    """
+
+    data_plaintext = base64ToUint8Array(message)
+    try:
+        ws_obj = json.loads(data_plaintext.decode())
+        if ws_obj.get("type") == "REQUEST" and ws_obj.get("request"):
+            body_b64 = ws_obj["request"].get("body")
+            if body_b64:
+                return base64.b64decode(body_b64)
+        return None
+    except Exception as exc:
+        raise ValueError("Failed to extract websocket content") from exc
+
+
+def _decode_envelope(data: bytes) -> Envelope:
+    obj = json.loads(data.decode())
+    content = base64.b64decode(obj["content"])
+    return Envelope(
+        type=EnvelopeType(obj["type"]),
+        source=obj.get("source"),
+        timestamp=int(obj["timestamp"]),
+        content=content,
+    )
+
+
+def decode_message(
+    body: bytes,
+    *,
+    override_source: Optional[str] = None,
+    our_pub_key: Optional[str] = None,
+) -> Optional[EnvelopePlus]:
+    """
+    Decode an envelope into an :class:`EnvelopePlus` structure.
+
+    Args:
+        override_source (Optional[str]): Override the source field.
+        our_pub_key (Optional[str]): Our own public key for filtering.
+
+    Returns:
+        Optional[EnvelopePlus]: Parsed envelope or ``None``.
+    """
+
+    envelope = _decode_envelope(body)
+    sender_identity = envelope.source
+    source = envelope.source
+
+    if override_source:
+        sender_identity = envelope.source
+        if sender_identity == our_pub_key:
+            return None
+        source = override_source
+
+    return EnvelopePlus(
+        id=str(uuid.uuid4()),
+        source=source,
+        content=envelope.content,
+        receivedAt=int(time.time() * 1000),
+        senderIdentity=sender_identity or source,
+        timestamp=envelope.timestamp,
+        type=envelope.type,
+    )
+
+
+def decrypt_message(keypairs: List[Keypair], envelope: EnvelopePlus) -> bytes:
+    """
+    Decrypt the content of an :class:`EnvelopePlus`.
+
+    Args:
+        keypairs (List[Keypair]): Available keypairs for decryption.
+        envelope (EnvelopePlus): Envelope plus metadata.
+
+    Returns:
+        bytes: Decrypted and unpadded plaintext.
+    """
+
+    if not envelope.content:
+        raise ValueError("Received an empty envelope")
+
+    if envelope.type == EnvelopeType.SESSION_MESSAGE:
+        return decrypt_envelope_with_our_key(keypairs[0], envelope)
+    if envelope.type == EnvelopeType.CLOSED_GROUP_MESSAGE:
+        return _decrypt_for_closed_group(list(keypairs), envelope)
+
+    raise ValueError(f"Unknown message type: {envelope.type}")
+
+
+def decrypt_envelope_with_our_key(keypair: Keypair, envelope: EnvelopePlus) -> bytes:
+    """
+    Decrypt an envelope addressed to us.
+
+    Args:
+        keypair (Keypair): Our keypair.
+        envelope (EnvelopePlus): Envelope to decrypt.
+
+    Returns:
+        bytes: Decrypted plaintext without padding.
+    """
+
+    plaintext = decrypt_with_session_protocol(keypair, envelope)
+    return remove_message_padding(plaintext)
+
+
+def _decrypt_for_closed_group(keypairs: List[Keypair], envelope: EnvelopePlus) -> bytes:
+    for _ in range(len(keypairs)):
+        kp = keypairs.pop()
+        try:
+            decrypted = decrypt_with_session_protocol(kp, envelope, is_closed_group=True)
+            if decrypted:
+                return remove_message_padding(decrypted)
+        except Exception:
+            pass
+    raise ValueError("Could not decrypt message for closed group")
+
+
+def decrypt_with_session_protocol(
+    keypair: Keypair,
+    envelope: EnvelopePlus,
+    *,
+    is_closed_group: bool = False,
+) -> bytes:
+    """
+    Low level decryption using the Session protocol.
+
+    Args:
+        keypair (Keypair): Keypair for decryption.
+        envelope (EnvelopePlus): Envelope to decrypt.
+        is_closed_group (bool): Whether this is a closed group message.
+
+    Returns:
+        bytes: Decrypted plaintext.
+    """
+
+    recipient_pub = removePrefixIfNeeded(keypair.x25519.publicKey)
+
+    plaintext_with_meta = bindings.crypto_box_seal_open(
+        envelope.content,
+        recipient_pub,
+        keypair.x25519.privateKey,
+    )
+    sig_size = bindings.crypto_sign_BYTES
+    pk_size = bindings.crypto_sign_PUBLICKEYBYTES
+    if len(plaintext_with_meta) <= sig_size + pk_size:
+        raise ValueError("Decryption failed")
+
+    signature = plaintext_with_meta[-sig_size:]
+    sender_ed_pub = plaintext_with_meta[-(sig_size + pk_size) : -sig_size]
+    plaintext = plaintext_with_meta[: -(sig_size + pk_size)]
+
+    verification_data = concatUInt8Array(plaintext, sender_ed_pub, recipient_pub)
+    try:
+        signing.VerifyKey(sender_ed_pub).verify(verification_data, signature)
+    except Exception as exc:
+        raise ValueError("Invalid message signature") from exc
+
+    sender_x_pub = bindings.crypto_sign_ed25519_pk_to_curve25519(sender_ed_pub)
+    if sender_x_pub is None:
+        raise ValueError("Failed to get sender public key")
+
+    identity_hex = Uint8ArrayToHex(sender_x_pub)
+    if is_closed_group:
+        envelope.senderIdentity = identity_hex
+    else:
+        envelope.source = identity_hex
+
+    return plaintext

--- a/session_py_client/crypto/message_encrypt.py
+++ b/session_py_client/crypto/message_encrypt.py
@@ -1,0 +1,272 @@
+"""Message encryption helpers using PyNaCl."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any, Dict, Iterable, List, Optional
+
+from nacl import bindings, public, signing
+
+from ..utils import concatUInt8Array, hexToUint8Array, removePrefixIfNeeded
+from .message_padding import add_message_padding
+
+
+class EnvelopeType(IntEnum):
+    """Enumeration of envelope types."""
+
+    SESSION_MESSAGE = 6
+    CLOSED_GROUP_MESSAGE = 7
+
+
+@dataclass
+class SodiumKeyPair:
+    """Wrapper around a sodium key pair."""
+
+    publicKey: bytes
+    privateKey: bytes
+
+
+@dataclass
+class Keypair:
+    """Combined X25519 and Ed25519 key pairs."""
+
+    x25519: SodiumKeyPair
+    ed25519: SodiumKeyPair
+
+
+@dataclass
+class Envelope:
+    """Simple representation of a message envelope."""
+
+    type: EnvelopeType
+    source: Optional[str]
+    timestamp: int
+    content: bytes
+
+
+def generate_keypair() -> Keypair:
+    """
+    Generate a new ``Keypair`` using random keys.
+
+    Returns:
+        Keypair: Generated key pair with X25519 and Ed25519 keys.
+    """
+
+    x_sk = public.PrivateKey.generate()
+    ed_sk = signing.SigningKey.generate()
+    return Keypair(
+        x25519=SodiumKeyPair(
+            publicKey=bytes(x_sk.public_key), privateKey=bytes(x_sk)
+        ),
+        ed25519=SodiumKeyPair(
+            publicKey=bytes(ed_sk.verify_key), privateKey=bytes(ed_sk)
+        ),
+    )
+
+
+@dataclass
+class EncryptResult:
+    """Result returned by :func:`encrypt`."""
+
+    envelopeType: EnvelopeType
+    cipherText: bytes
+
+
+def encrypt(
+    sender_keypair: Keypair,
+    recipient: str,
+    plain_text_buffer: bytes,
+    encryption_type: EnvelopeType,
+) -> EncryptResult:
+    """
+    Encrypt a plaintext message using the Session protocol.
+
+    Args:
+        sender_keypair (Keypair): Our keypair used for signing.
+        recipient (str): Recipient Session ID (hex string).
+        plain_text_buffer (bytes): Plaintext message to encrypt.
+        encryption_type (EnvelopeType): Envelope type to use.
+
+    Returns:
+        EncryptResult: Envelope type and ciphertext.
+    """
+
+    if encryption_type not in (
+        EnvelopeType.CLOSED_GROUP_MESSAGE,
+        EnvelopeType.SESSION_MESSAGE,
+    ):
+        raise ValueError(f"Invalid encryption type: {encryption_type}")
+
+    padded = add_message_padding(plain_text_buffer)
+
+    cipher_text = _encrypt_using_session_protocol(
+        sender_keypair, recipient, padded
+    )
+
+    return EncryptResult(encryption_type, cipher_text)
+
+
+def _encrypt_using_session_protocol(
+    sender_keypair: Keypair, recipient: str, plaintext: bytes
+) -> bytes:
+    """
+    Perform low level Session encryption steps.
+
+    Args:
+        sender_keypair (Keypair): Our keypair used for signing.
+        recipient (str): Hex encoded X25519 recipient public key.
+        plaintext (bytes): Padded plaintext message.
+
+    Returns:
+        bytes: Ciphertext produced by ``crypto_box_seal``.
+    """
+
+    ed_priv = sender_keypair.ed25519.privateKey
+    ed_pub = sender_keypair.ed25519.publicKey
+    if not ed_priv or not ed_pub:
+        raise ValueError("Missing Ed25519 keypair")
+
+    recipient_pub = hexToUint8Array(removePrefixIfNeeded(recipient))
+
+    verification_data = concatUInt8Array(plaintext, ed_pub, recipient_pub)
+    signature = signing.SigningKey(ed_priv).sign(verification_data).signature
+
+    plaintext_with_meta = concatUInt8Array(plaintext, ed_pub, signature)
+
+    return bindings.crypto_box_seal(plaintext_with_meta, recipient_pub)
+
+
+def build_envelope(
+    type_: EnvelopeType,
+    ssk_source: Optional[str],
+    timestamp: int,
+    content: bytes,
+) -> Envelope:
+    """
+    Build an :class:`Envelope` instance.
+
+    Args:
+        type_ (EnvelopeType): Envelope type.
+        ssk_source (Optional[str]): Source identity for closed groups.
+        timestamp (int): Message timestamp.
+        content (bytes): Ciphertext content.
+
+    Returns:
+        Envelope: Constructed envelope object.
+    """
+
+    source = ssk_source if type_ == EnvelopeType.CLOSED_GROUP_MESSAGE else None
+    return Envelope(type=type_, source=source, timestamp=timestamp, content=content)
+
+
+def _encode_envelope(envelope: Envelope) -> bytes:
+    obj = {
+        "type": int(envelope.type),
+        "source": envelope.source,
+        "timestamp": envelope.timestamp,
+        "content": base64.b64encode(envelope.content).decode("ascii"),
+    }
+    return json.dumps(obj).encode()
+
+
+def wrap_envelope(envelope: Envelope) -> bytes:
+    """
+    Wrap an :class:`Envelope` into a websocket style container.
+
+    Args:
+        envelope (Envelope): Envelope to wrap.
+
+    Returns:
+        bytes: Encoded websocket message.
+    """
+
+    body = base64.b64encode(_encode_envelope(envelope)).decode("ascii")
+    websocket = {
+        "type": "REQUEST",
+        "request": {
+            "id": 0,
+            "verb": "PUT",
+            "path": "/api/v1/message",
+            "body": body,
+        },
+    }
+    return json.dumps(websocket).encode()
+
+
+class EncryptAndWrapMessage(Dict[str, Any]):
+    pass
+
+
+class EncryptAndWrapMessageResults(Dict[str, Any]):
+    pass
+
+
+def wrap(
+    sender_keypair: Keypair,
+    messages: Iterable[EncryptAndWrapMessage],
+    *,
+    network_timestamp: int,
+) -> List[EncryptAndWrapMessageResults]:
+    """
+    Encrypt and wrap multiple messages for sending.
+
+    Args:
+        sender_keypair (Keypair): Our keypair used for signing.
+        messages (Iterable[EncryptAndWrapMessage]): Messages to process.
+        network_timestamp (int): Timestamp to include in envelopes.
+
+    Returns:
+        List[EncryptAndWrapMessageResults]: Encoded message descriptors.
+    """
+
+    results: List[EncryptAndWrapMessageResults] = []
+    for msg in messages:
+        destination = msg.get("destination")
+        is_group = bool(msg.get("isGroup"))
+        plaintext = msg.get("plainTextBuffer", b"")
+        namespace = msg.get("namespace")
+        ttl = msg.get("ttl")
+        identifier = msg.get("identifier")
+        sync_message = msg.get("isSyncMessage", False)
+
+        envelope_type = (
+            EnvelopeType.CLOSED_GROUP_MESSAGE
+            if is_group
+            else EnvelopeType.SESSION_MESSAGE
+        )
+        enc = encrypt(
+            sender_keypair,
+            destination,
+            plaintext,
+            envelope_type,
+        )
+        envelope = build_envelope(
+            enc.envelopeType,
+            destination if is_group else None,
+            network_timestamp,
+            enc.cipherText,
+        )
+        data = wrap_envelope(envelope)
+        data64 = base64.b64encode(data).decode("ascii")
+        overriden_namespace = (
+            namespace
+            if namespace is not None
+            else (
+                -10 if is_group else 0
+            )
+        )
+        results.append(
+            {
+                "data64": data64,
+                "networkTimestamp": network_timestamp,
+                "data": data,
+                "namespace": overriden_namespace,
+                "ttl": ttl,
+                "identifier": identifier,
+                "isSyncMessage": sync_message,
+            }
+        )
+    return results

--- a/session_py_client/crypto/message_padding.py
+++ b/session_py_client/crypto/message_padding.py
@@ -1,0 +1,54 @@
+"""Message padding utilities compatible with the JS client."""
+
+from __future__ import annotations
+
+
+PADDING_BYTE = 0x00
+
+
+def remove_message_padding(padded_plaintext: bytes) -> bytes:
+    """
+    Remove padding bytes from a padded message.
+
+    Args:
+        padded_plaintext (bytes): Padded plaintext as returned by
+            ``add_message_padding``.
+
+    Returns:
+        bytes: Original message without padding.
+
+    Raises:
+        ValueError: If padding markers are invalid.
+    """
+    for i in range(len(padded_plaintext) - 1, -1, -1):
+        value = padded_plaintext[i]
+        if value == 0x80:
+            return padded_plaintext[:i]
+        if value != PADDING_BYTE:
+            return padded_plaintext
+    raise ValueError("Invalid padding")
+
+
+def add_message_padding(message: bytes) -> bytes:
+    """
+    Add padding bytes according to Session message rules.
+
+    Args:
+        message (bytes): Plaintext message to pad.
+
+    Returns:
+        bytes: Padded message ready for encryption.
+    """
+    padded_len = _get_padded_message_length(len(message) + 1) - 1
+    plaintext = bytearray(padded_len)
+    plaintext[: len(message)] = message
+    plaintext[len(message)] = 0x80
+    return bytes(plaintext)
+
+
+def _get_padded_message_length(original_length: int) -> int:
+    message_length_with_terminator = original_length + 1
+    message_part_count = message_length_with_terminator // 160
+    if message_length_with_terminator % 160 != 0:
+        message_part_count += 1
+    return message_part_count * 160

--- a/session_py_client/tests/test_crypto.py
+++ b/session_py_client/tests/test_crypto.py
@@ -1,0 +1,41 @@
+import base64
+
+from session_py_client.crypto import (
+    generate_keypair,
+    encrypt,
+    decrypt_envelope_with_our_key,
+    build_envelope,
+    wrap_envelope,
+    extract_content,
+    decode_message,
+    EnvelopeType,
+    add_message_padding,
+    remove_message_padding,
+)
+
+
+def test_message_padding_roundtrip():
+    msg = b"test"
+    padded = add_message_padding(msg)
+    assert padded != msg
+    plain = remove_message_padding(padded)
+    assert plain == msg
+
+
+def test_encrypt_decrypt_roundtrip():
+    sender = generate_keypair()
+    recipient = generate_keypair()
+
+    plaintext = b"hello world"
+    enc = encrypt(sender, base64.b16encode(recipient.x25519.publicKey).decode("ascii"), plaintext, EnvelopeType.SESSION_MESSAGE)
+    env = build_envelope(EnvelopeType.SESSION_MESSAGE, None, 12345, enc.cipherText)
+    wrapped = wrap_envelope(env)
+    data64 = base64.b64encode(wrapped).decode("ascii")
+
+    body = extract_content(data64)
+    assert body is not None
+    env_plus = decode_message(body)
+    assert env_plus is not None
+
+    decrypted = decrypt_envelope_with_our_key(recipient, env_plus)
+    assert decrypted == plaintext


### PR DESCRIPTION
## Summary
- implement message padding helpers
- add message encryption and wrapping utilities
- add message decryption helpers
- expose crypto helpers in package init
- test encryption, decryption and padding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c46cc27bc832ead2b4335fb8720ba