### PR TITLE
feat(sogs): add SOGS utilities with signing

### DIFF
--- a/session_py_client/__init__.py
+++ b/session_py_client/__init__.py
@@ -36,6 +36,12 @@ from .attachments.encrypt import (
 from .attachments.decrypt import decryptAttachment
 from .session import Session
 from .mnemonic import decode_mnemonic
+from .sogs import (
+    blind_session_id,
+    encode_sogs_message,
+    sign_sogs_request,
+    send_sogs_request,
+)
 from .crypto import (
     add_message_padding,
     remove_message_padding,
@@ -115,6 +121,10 @@ __all__ = [
     "RawMessage",
     "to_raw_message",
     "decrypt_with_session_protocol",
+    "blind_session_id",
+    "encode_sogs_message",
+    "sign_sogs_request",
+    "send_sogs_request",
     "Session",
 ]
 

--- a/session_py_client/sogs.py
+++ b/session_py_client/sogs.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+"""SOGS utilities compatible with Session.py."""
+
+import base64
+import time
+from typing import Any, Optional
+
+from nacl import bindings, utils
+
+from .crypto import add_message_padding, Keypair
+from .utils import (
+    Uint8ArrayToBase64,
+    hexToUint8Array,
+    SessionValidationError,
+    SessionValidationErrorCode,
+)
+from network import (
+    sign_sogs_request as _sign_sogs_request,
+    _get_blinding_values,
+    _blinded_ed25519_signature,
+)
+
+
+async def blind_session_id(self: Any, server_pk: str) -> str:
+    """Return blinded Session ID using server public key."""
+
+    if getattr(self, "session_id", None) is None or getattr(self, "keypair", None) is None:
+        raise SessionValidationError(SessionValidationErrorCode.INVALID_OPTIONS, "Instance is not initialized")
+    blinding = _get_blinding_values(hexToUint8Array(server_pk), self.keypair.ed25519)
+    return "15" + blinding["publicKey"].hex()
+
+
+def encode_sogs_message(
+    self: Any,
+    *,
+    server_pk: str,
+    message: Any,
+    blind: bool,
+) -> dict[str, str]:
+    """Encode a message for SOGS storage and return data and signature."""
+
+    if getattr(self, "session_id", None) is None or getattr(self, "keypair", None) is None:
+        raise SessionValidationError(SessionValidationErrorCode.INVALID_OPTIONS, "Instance is not initialized")
+
+    padded = add_message_padding(message.plain_text_buffer())
+    data = Uint8ArrayToBase64(padded)
+
+    if blind:
+        blinding = _get_blinding_values(hexToUint8Array(server_pk), self.keypair.ed25519)
+        sig_bytes = _blinded_ed25519_signature(
+            padded,
+            self.keypair,
+            blinding["secretKey"],
+            blinding["publicKey"],
+        )
+        signature = Uint8ArrayToBase64(sig_bytes)
+    else:
+        sig_bytes = bindings.crypto_sign_detached(padded, self.keypair.ed25519.privateKey)
+        signature = Uint8ArrayToBase64(sig_bytes)
+
+    return {"data": data, "signature": signature}
+
+
+def sign_sogs_request(
+    self: Any,
+    *,
+    blind: bool,
+    server_pk: str,
+    timestamp: int,
+    endpoint: str,
+    nonce: bytes,
+    method: str,
+    body: Optional[bytes] = None,
+) -> bytes:
+    """Sign a SOGS request."""
+
+    if getattr(self, "session_id", None) is None or getattr(self, "keypair", None) is None:
+        raise SessionValidationError(SessionValidationErrorCode.INVALID_OPTIONS, "Instance is not initialized")
+    return _sign_sogs_request(
+        blind=blind,
+        server_pk=server_pk,
+        timestamp=timestamp,
+        endpoint=endpoint,
+        nonce=nonce,
+        method=method,
+        keypair=self.keypair,
+        body=body,
+    )
+
+
+async def send_sogs_request(
+    self: Any,
+    *,
+    host: str,
+    server_pk: str,
+    endpoint: str,
+    method: str,
+    body: Optional[Any] = None,
+    blind: bool = True,
+) -> Any:
+    """Encrypt, sign and send a request to a SOGS server."""
+
+    if getattr(self, "session_id", None) is None or getattr(self, "keypair", None) is None:
+        raise SessionValidationError(SessionValidationErrorCode.INVALID_OPTIONS, "Instance is not initialized")
+    if getattr(self, "network", None) is None:
+        raise SessionValidationError(SessionValidationErrorCode.INVALID_OPTIONS, "Network not configured")
+
+    nonce = utils.random(16)
+    timestamp = int(time.time())
+
+    body_bytes = None
+    if isinstance(body, str):
+        body_bytes = body.encode()
+    elif isinstance(body, (bytes, bytearray)):
+        body_bytes = bytes(body)
+
+    signature = sign_sogs_request(
+        self,
+        blind=blind,
+        server_pk=server_pk,
+        timestamp=timestamp,
+        endpoint=endpoint,
+        nonce=nonce,
+        method=method,
+        body=body_bytes,
+    )
+
+    if blind:
+        pubkey = await blind_session_id(self, server_pk)
+    else:
+        pubkey = "00" + self.keypair.ed25519.publicKey.hex()
+
+    content_type = None
+    processed_body = None
+    if body is not None:
+        if isinstance(body, (bytes, bytearray)):
+            content_type = "application/octet-stream"
+            processed_body = bytes(body)
+        else:
+            content_type = "application/json"
+            processed_body = body
+
+    headers = {
+        "X-SOGS-Pubkey": pubkey,
+        "X-SOGS-Timestamp": str(timestamp),
+        "X-SOGS-Nonce": base64.b64encode(nonce).decode("ascii"),
+        "X-SOGS-Signature": base64.b64encode(signature).decode("ascii"),
+    }
+    if content_type:
+        headers["Content-Type"] = content_type
+
+    request_body = {
+        "host": host,
+        "endpoint": endpoint,
+        "method": method,
+        "body": processed_body,
+        "headers": headers,
+    }
+
+    return await self.network.on_request("sogs_request", request_body)

--- a/session_py_client/tests/test_sogs.py
+++ b/session_py_client/tests/test_sogs.py
@@ -1,0 +1,81 @@
+import asyncio
+from nacl import bindings, signing, hash
+from nacl.encoding import RawEncoder
+
+from session_py_client import Session
+from session_py_client.sogs import blind_session_id, sign_sogs_request
+from session_py_client.utils import hexToUint8Array
+from network import _get_blinding_values, _blinded_ed25519_signature
+
+
+def setup_session():
+    session = Session()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(session.set_mnemonic("seed words for tests"))
+    loop.close()
+    asyncio.set_event_loop(None)
+    return session
+
+
+def test_blind_session_id():
+    session = setup_session()
+    server_pk = "11" * 32
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    blinded = loop.run_until_complete(blind_session_id(session, server_pk))
+    loop.close()
+    asyncio.set_event_loop(None)
+    assert blinded.startswith("15") and len(blinded) == 66
+
+
+def test_sign_sogs_request_unblinded():
+    session = setup_session()
+    server_pk = "22" * 32
+    nonce = b"\x00" * 16
+    timestamp = 1700000000
+    endpoint = "/test"
+    method = "POST"
+    body = b"{}"
+    sig = sign_sogs_request(
+        session,
+        blind=False,
+        server_pk=server_pk,
+        timestamp=timestamp,
+        endpoint=endpoint,
+        nonce=nonce,
+        method=method,
+        body=body,
+    )
+    pk = hexToUint8Array(server_pk)
+    to_sign = pk + nonce + str(timestamp).encode() + method.encode() + endpoint.encode()
+    to_sign += hash.blake2b(body, digest_size=64, encoder=RawEncoder)
+    signing.VerifyKey(session.keypair.ed25519.publicKey).verify(to_sign, sig)
+
+
+def test_sign_sogs_request_blinded():
+    session = setup_session()
+    server_pk = "33" * 32
+    nonce = b"\x01" * 16
+    timestamp = 1700000001
+    endpoint = "/path"
+    method = "GET"
+    sig = sign_sogs_request(
+        session,
+        blind=True,
+        server_pk=server_pk,
+        timestamp=timestamp,
+        endpoint=endpoint,
+        nonce=nonce,
+        method=method,
+    )
+    pk_bytes = hexToUint8Array(server_pk)
+    to_sign = pk_bytes + nonce + str(timestamp).encode() + method.encode() + endpoint.encode()
+    blinding = _get_blinding_values(pk_bytes, session.keypair.ed25519)
+    expected = _blinded_ed25519_signature(
+        to_sign,
+        session.keypair,
+        blinding["secretKey"],
+        blinding["publicKey"],
+    )
+    assert sig == expected


### PR DESCRIPTION
## Summary
- implement SOGS helpers for Python client
- export new functions in package
- adjust network helpers for PyNaCl compatibility
- add tests for SOGS signature and blinding

## Testing
- `pytest session_py_client/tests -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'polling')*

------
https://chatgpt.com/codex/tasks/task_e_686d57571404832ea2938c31395ff0ae