### PR TITLE
Add tests for SOGS and avatars

### DIFF
--- a/session_py_client/README.md
+++ b/session_py_client/README.md
@@ -64,6 +64,44 @@ async def update_avatar(session: Session, avatar_bytes: bytes):
     await session.network.on_request("set_profile", data)
 ```
 
+### SOGS Utilities
+
+`session_py_client.sogs` exposes helpers to interact with Session Open Group Service.
+
+```python
+from session_py_client.sogs import encode_sogs_message, send_sogs_request
+
+message_data = encode_sogs_message(
+    session,
+    server_pk="11" * 32,
+    message=my_message,
+    blind=True,
+)
+response = await send_sogs_request(
+    session,
+    host="https://sogs.example.com",
+    server_pk="11" * 32,
+    endpoint="/rooms",
+    method="POST",
+    body=message_data["data"],
+)
+```
+
+### Message Dataclasses
+
+Several dataclasses mirror the message schema used by Session. They provide
+`content_proto()` helpers returning ready-to-send protobuf structures.
+
+```python
+from session_py_client.messages import TypingMessage, DataExtractionNotificationMessage
+
+typing = TypingMessage(timestamp=123, is_typing=True)
+typing_proto = typing.content_proto()
+
+notification = DataExtractionNotificationMessage(timestamp=456)
+notification_proto = notification.content_proto()
+```
+
 ## Migrating from TypeScript/Bun
 
 1. Replace `import { Session } from "session.js"` with `from session_py_client import Session`.

--- a/session_py_client/tests/test_avatar.py
+++ b/session_py_client/tests/test_avatar.py
@@ -1,0 +1,60 @@
+import asyncio
+import os
+
+from session_py_client.profile import (
+    upload_avatar,
+    download_avatar,
+    Avatar,
+    PROFILE_KEY_LENGTH,
+)
+
+class DummySession:
+    def __init__(self):
+        self.requests = []
+
+    async def _request(self, req):
+        self.requests.append((req["type"], req.get("body")))
+        if req["type"] == "UploadAttachment":
+            return {"url": "http://filev2.getsession.org/file/42"}
+        if req["type"] == "DownloadAttachment":
+            return b"encrypted"
+        return None
+
+def test_upload_avatar(monkeypatch):
+    session = DummySession()
+
+    monkeypatch.setattr(
+        "session_py_client.profile.encrypt_profile", lambda data, key: b"enc" + data
+    )
+    monkeypatch.setattr(os, "urandom", lambda n: b"\x01" * n)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    result = loop.run_until_complete(upload_avatar(session, b"img"))
+    loop.close()
+    asyncio.set_event_loop(None)
+
+    assert result["avatarPointer"].endswith("42")
+    assert result["profileKey"] == b"\x01" * PROFILE_KEY_LENGTH
+    req_type, body = session.requests[0]
+    assert req_type == "UploadAttachment"
+    assert body["data"] == b"enc" + b"img"
+
+def test_download_avatar(monkeypatch):
+    session = DummySession()
+    avatar = Avatar(url="http://filev2.getsession.org/file/42", key=b"k" * PROFILE_KEY_LENGTH)
+
+    monkeypatch.setattr(
+        "session_py_client.profile.decrypt_profile", lambda data, key: b"dec"
+    )
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    result = loop.run_until_complete(download_avatar(session, avatar))
+    loop.close()
+    asyncio.set_event_loop(None)
+
+    assert result == b"dec"
+    req_type, body = session.requests[0]
+    assert req_type == "DownloadAttachment"
+    assert body["id"] == "42"

--- a/session_py_client/tests/test_messages.py
+++ b/session_py_client/tests/test_messages.py
@@ -1,0 +1,59 @@
+from session_py_client.messages import (
+    TypingMessage,
+    DataExtractionNotificationMessage,
+    SharedConfigMessage,
+    MessageRequestResponse,
+    UnsendMessage,
+)
+from session_py_client.profile import Profile, Avatar
+from session_py_client.protobuf import signalservice_pb2
+
+
+def test_typing_message_proto():
+    msg = TypingMessage(timestamp=1, is_typing=True, typing_timestamp=2)
+    proto = msg.typing_proto()
+    assert proto.action == signalservice_pb2.TypingMessage.STARTED
+    assert proto.timestamp == 2
+    assert msg.ttl() == 20 * 1000
+
+
+def test_data_extraction_notification_message_proto():
+    msg = DataExtractionNotificationMessage(
+        timestamp=3,
+        action=signalservice_pb2.DataExtractionNotification.MEDIA_SAVED,
+        extraction_timestamp=4,
+    )
+    proto = msg.data_extraction_proto()
+    assert proto.type == signalservice_pb2.DataExtractionNotification.MEDIA_SAVED
+    assert proto.timestamp == 4
+
+
+def test_shared_config_message_proto():
+    msg = SharedConfigMessage(
+        timestamp=5,
+        seqno=7,
+        kind=signalservice_pb2.SharedConfigMessage.USER_PROFILE,
+        data=b"abc",
+    )
+    proto = msg.shared_config_proto()
+    assert proto.seqno == 7
+    assert proto.kind == signalservice_pb2.SharedConfigMessage.USER_PROFILE
+    assert proto.data == b"abc"
+    assert msg.ttl() == 30 * 24 * 60 * 60 * 1000
+
+
+def test_message_request_response_proto():
+    profile = Profile(display_name="Bob", avatar=Avatar(url="http://filev2.getsession.org/file/1", key=b"k" * 32))
+    msg = MessageRequestResponse(timestamp=6, profile=profile)
+    proto = msg.message_request_response_proto()
+    assert proto.isApproved is True
+    assert proto.profile.displayName == "Bob"
+    assert proto.profile.profilePicture == profile.avatar.url
+    assert proto.profileKey == profile.avatar.key
+
+
+def test_unsend_message_proto():
+    msg = UnsendMessage(timestamp=7, author="alice")
+    proto = msg.unsend_proto()
+    assert proto.timestamp == 7
+    assert proto.author == "alice"

--- a/session_py_client/tests/test_sogs.py
+++ b/session_py_client/tests/test_sogs.py
@@ -1,10 +1,18 @@
 import asyncio
-from nacl import bindings, signing, hash
+from nacl import signing, hash
 from nacl.encoding import RawEncoder
 
 from session_py_client import Session
-from session_py_client.sogs import blind_session_id, sign_sogs_request
+from session_py_client.sogs import (
+    blind_session_id,
+    sign_sogs_request,
+    encode_sogs_message,
+    send_sogs_request,
+)
+import session_py_client.sogs as sogs
 from session_py_client.utils import hexToUint8Array
+from session_py_client.crypto import add_message_padding
+import base64
 from network import _get_blinding_values, _blinded_ed25519_signature
 
 
@@ -79,3 +87,82 @@ def test_sign_sogs_request_blinded():
         blinding["publicKey"],
     )
     assert sig == expected
+
+
+def test_encode_sogs_message(monkeypatch):
+    session = setup_session()
+    server_pk = "44" * 32
+
+    class DummyMessage:
+        def plain_text_buffer(self):
+            return b"hello"
+
+    monkeypatch.setattr(
+        sogs.bindings,
+        "crypto_sign_detached",
+        lambda msg, sk: signing.SigningKey(sk).sign(msg).signature,
+        raising=False,
+    )
+
+    result = encode_sogs_message(
+        session,
+        server_pk=server_pk,
+        message=DummyMessage(),
+        blind=False,
+    )
+
+    padded = add_message_padding(b"hello")
+    assert base64.b64decode(result["data"]) == padded
+    signing.VerifyKey(session.keypair.ed25519.publicKey).verify(
+        padded,
+        base64.b64decode(result["signature"]),
+    )
+
+
+def test_send_sogs_request(monkeypatch):
+    session = setup_session()
+
+    class DummyNetwork:
+        def __init__(self):
+            self.requests = []
+
+        async def on_request(self, type_, body):
+            self.requests.append((type_, body))
+            return {"ok": True}
+
+    session.network = DummyNetwork()
+
+    monkeypatch.setattr(sogs, "sign_sogs_request", lambda *a, **k: b"sig")
+    async def fake_blind(*a, **k):
+        return "15" + "00" * 32
+
+    monkeypatch.setattr(sogs, "blind_session_id", fake_blind)
+    monkeypatch.setattr(sogs.utils, "random", lambda n: b"\x00" * n)
+    monkeypatch.setattr(sogs.time, "time", lambda: 1700000002)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(
+        send_sogs_request(
+            session,
+            host="https://sogs.example.com",
+            server_pk="11" * 32,
+            endpoint="/test",
+            method="POST",
+            body="{}",
+            blind=True,
+        )
+    )
+    loop.close()
+    asyncio.set_event_loop(None)
+
+    req_type, body = session.network.requests[0]
+    assert req_type == "sogs_request"
+    assert body["endpoint"] == "/test"
+    assert body["method"] == "POST"
+    assert body["body"] == "{}"
+    headers = body["headers"]
+    assert headers["X-SOGS-Pubkey"].startswith("15")
+    assert headers["X-SOGS-Timestamp"] == "1700000002"
+    assert headers["X-SOGS-Nonce"] == base64.b64encode(b"\x00" * 16).decode("ascii")
+    assert headers["X-SOGS-Signature"] == base64.b64encode(b"sig").decode("ascii")


### PR DESCRIPTION
## Summary
- add detailed docs on SOGS helpers and message dataclasses
- cover avatar upload/download helpers
- test SOGS encoding and request helpers
- add unit tests for new message dataclasses

## Testing
- `pytest -q session_py_client/tests/test_sogs.py::test_encode_sogs_message -s`
- `pytest -q session_py_client/tests/test_sogs.py::test_send_sogs_request -s`
- `pytest -q session_py_client/tests/test_avatar.py -s`
- `pytest -q session_py_client/tests/test_messages.py -s`
- `pytest -q session_py_client/tests -s`

------
https://chatgpt.com/codex/tasks/task_e_686e78c7c2b0832e81d89777013d6c45