### PR TITLE
feat(py-sample): generate mnemonic when missing

### DIFF
--- a/session_py_client/__init__.py
+++ b/session_py_client/__init__.py
@@ -36,7 +36,7 @@ from .attachments.encrypt import (
 )
 from .attachments.decrypt import decryptAttachment
 from .session import Session
-from .mnemonic import decode_mnemonic
+from .mnemonic import decode_mnemonic, generate_mnemonic
 from .sogs import (
     blind_session_id,
     encode_sogs_message,
@@ -129,6 +129,7 @@ __all__ = [
     "generate_keypair",
     "get_keypair_from_seed",
     "decode_mnemonic",
+    "generate_mnemonic",
     "encrypt",
     "wrap_envelope",
     "build_envelope",

--- a/session_py_client/mnemonic.py
+++ b/session_py_client/mnemonic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import binascii
+import random
 from pathlib import Path
 from typing import List
 
@@ -72,3 +73,19 @@ def decode_mnemonic(mnemonic: str) -> str:
         if expected != checksum_word[:_PREFIX_LEN]:
             raise ValueError("Invalid checksum word")
     return out.hex()
+
+
+def generate_mnemonic(num_words: int = 12) -> str:
+    """Generate a random mnemonic with checksum."""
+
+    if num_words < 12 or num_words % 3 != 0:
+        raise ValueError("num_words must be a multiple of 3 and at least 12")
+
+    words = load_words()
+    chosen = [random.choice(words) for _ in range(num_words)]
+
+    index = _get_checksum_index(chosen)
+    prefix = chosen[index][:_PREFIX_LEN]
+    checksum = next((w for w in words if w.startswith(prefix)), chosen[index])
+
+    return " ".join(chosen + [checksum])

--- a/session_py_client/sample/simple_bot.py
+++ b/session_py_client/sample/simple_bot.py
@@ -1,5 +1,11 @@
 import asyncio
 import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from network import Network
 from polling.poller import Poller, NetworkModule

--- a/session_py_client/sample/simple_bot.py
+++ b/session_py_client/sample/simple_bot.py
@@ -13,18 +13,33 @@ from polling.poller import Poller, NetworkModule
 
 
 class MessageNetwork(NetworkModule):
-    """Network module fetching messages using the base network layer."""
+    """
+    Network module fetching messages from the base network layer.
+
+    Args:
+        session (Session): Active session used to perform requests.
+    """
 
     def __init__(self, session: Session) -> None:
         self._session = session
 
-    async def fetch_messages(self):
-        """Fetch new messages from the server."""
+    async def fetch_messages(self) -> list:
+        """
+        Fetch new messages from the server.
+
+        Returns:
+            list: Raw message dictionaries returned by the network.
+        """
         return await self._session.network.on_request("fetch_messages", None)
 
 
 async def main() -> None:
-    """Run a simple echo bot that replies to incoming messages."""
+    """
+    Run a simple echo bot that replies to incoming messages.
+
+    The bot generates a mnemonic if none is provided, prints the mnemonic and
+    contact ID, then polls for messages and echoes each one back to the sender.
+    """
     base_url = os.environ.get("SESSION_BASE_URL", "https://backend.getsession.org")
     mnemonic = os.environ.get("SESSION_MNEMONIC")
 
@@ -40,7 +55,13 @@ async def main() -> None:
     poller = Poller(MessageNetwork(session), interval=5.0)
     session.add_poller(poller)
 
-    def on_messages(msgs):
+    def on_messages(msgs: list) -> None:
+        """
+        Handle newly received messages.
+
+        Args:
+            msgs (list): List of message dictionaries.
+        """
         for msg in msgs:
             sender = msg.get("from")
             text = msg.get("body")

--- a/session_py_client/sample/simple_bot.py
+++ b/session_py_client/sample/simple_bot.py
@@ -1,0 +1,54 @@
+import asyncio
+import os
+
+from network import Network
+from polling.poller import Poller, NetworkModule
+from session_py_client import Session, generate_mnemonic
+
+
+class MessageNetwork(NetworkModule):
+    """Network module fetching messages using the base network layer."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    async def fetch_messages(self):
+        """Fetch new messages from the server."""
+        return await self._session.network.on_request("fetch_messages", None)
+
+
+async def main() -> None:
+    """Run a simple echo bot that replies to incoming messages."""
+    base_url = os.environ.get("SESSION_BASE_URL", "https://backend.getsession.org")
+    mnemonic = os.environ.get("SESSION_MNEMONIC")
+
+    network = Network(base_url)
+    session = Session(network=network)
+
+    if not mnemonic:
+        mnemonic = generate_mnemonic()
+        print("Mnemonic:", mnemonic)
+    await session.set_mnemonic(mnemonic)
+    print("Contact ID:", session.get_session_id())
+
+    poller = Poller(MessageNetwork(session), interval=5.0)
+    session.add_poller(poller)
+
+    def on_messages(msgs):
+        for msg in msgs:
+            sender = msg.get("from")
+            text = msg.get("body")
+            print("Received from", sender + ":", text)
+            if sender:
+                asyncio.create_task(
+                    session.send_message(sender, f"Echo: {text}")
+                )
+
+    session.on("messages", on_messages)
+
+    await asyncio.sleep(30)
+    await network.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/session_py_client/sample/simple_bot.py
+++ b/session_py_client/sample/simple_bot.py
@@ -7,9 +7,9 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from session_py_client import Session, generate_mnemonic
 from network import Network
 from polling.poller import Poller, NetworkModule
-from session_py_client import Session, generate_mnemonic
 
 
 class MessageNetwork(NetworkModule):


### PR DESCRIPTION
## Summary
- add `generate_mnemonic` helper
- export new helper in package init
- update sample bot to generate and show mnemonic and contact ID
- remove TARGET_SESSION_ID usage and reply to sender

## Testing
- `PYTHONPATH=. pytest -q polling/tests/test_poller.py`
- `PYTHONPATH=. pytest -q session_py_client/tests`
- `bun test` *(fails: Couldn't fetch https://37.27.42.197:22021/storage_rpc/v1)*

------
https://chatgpt.com/codex/tasks/task_e_686eaf75713c832e8bb7f18d9e5f7072